### PR TITLE
Run tests, deploy, and review

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "vercel-build": "next build",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint"

--- a/src/alphagen/storage.py
+++ b/src/alphagen/storage.py
@@ -14,6 +14,7 @@ from src.alphagen.config import load_app_config
 
 
 class EquityTickRow(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
     id: int | None = Field(default=None, primary_key=True)
     symbol: str
     price: float
@@ -23,6 +24,7 @@ class EquityTickRow(SQLModel, table=True):
 
 
 class OptionQuoteRow(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
     id: int | None = Field(default=None, primary_key=True)
     option_symbol: str
     strike: float
@@ -33,6 +35,7 @@ class OptionQuoteRow(SQLModel, table=True):
 
 
 class PositionSnapshotRow(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
     id: int | None = Field(default=None, primary_key=True)
     symbol: str
     quantity: int
@@ -42,6 +45,7 @@ class PositionSnapshotRow(SQLModel, table=True):
 
 
 class NormalizedTickRow(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
     id: int | None = Field(default=None, primary_key=True)
     as_of: datetime
     equity_symbol: str
@@ -49,20 +53,24 @@ class NormalizedTickRow(SQLModel, table=True):
     session_vwap: float
     ma9: float
     option_symbol: str | None
+    option_strike: float | None
     option_bid: float | None
     option_ask: float | None
 
 
 class SignalRow(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
     id: int | None = Field(default=None, primary_key=True)
     action: str
     option_symbol: str
+    reference_price: float
     rationale: str
     as_of: datetime
     cooldown_until: datetime
 
 
 class TradeIntentRow(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
     id: int | None = Field(default=None, primary_key=True)
     action: str
     option_symbol: str
@@ -74,6 +82,7 @@ class TradeIntentRow(SQLModel, table=True):
 
 
 class ExecutionRow(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
     id: int | None = Field(default=None, primary_key=True)
     order_id: str
     status: str
@@ -158,6 +167,7 @@ async def insert_signal(signal: "Signal") -> None:
             SignalRow(
                 action=signal.action,
                 option_symbol=signal.option_symbol,
+                reference_price=signal.reference_price,
                 rationale=signal.rationale,
                 as_of=signal.as_of,
                 cooldown_until=signal.cooldown_until,
@@ -224,6 +234,7 @@ async def insert_normalized_tick(tick: "NormalizedTick") -> None:
                 session_vwap=tick.equity.session_vwap,
                 ma9=tick.equity.ma9,
                 option_symbol=option.option_symbol if option else None,
+                option_strike=option.strike if option else None,
                 option_bid=option.bid if option else None,
                 option_ask=option.ask if option else None,
             )

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "env": {
+    "NEXT_PUBLIC_WS_URL": "wss://alpha-gen-backend.railway.app/ws/market-data",
+    "NEXT_PUBLIC_API_URL": "https://alpha-gen-backend.railway.app"
+  }
+}


### PR DESCRIPTION
Add `extend_existing=True` to SQLModel tables and update `NormalizedTickRow` and `SignalRow` with new fields.

This resolves SQLAlchemy table redefinition errors and aligns database models with current data structures, improving model accuracy and enabling more comprehensive test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec189ab5-c3da-4576-b013-99ec15333c5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec189ab5-c3da-4576-b013-99ec15333c5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

